### PR TITLE
Allow use of hip SDK (if installed) dlls on windows

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -187,10 +187,9 @@ def init_library():
         os.add_dll_directory(abs_path)
         os.add_dll_directory(os.getcwd())
         if libname == lib_hipblas and "HIP_PATH" in os.environ:
-            print(
-                f"HIP/ROCm SDK at {os.environ['HIP_PATH']} included in .DLL load path"
-            )
             os.add_dll_directory(os.path.join(os.environ["HIP_PATH"], "bin"))
+            if args.debugmode == 1:
+                print(f"HIP/ROCm SDK at {os.environ['HIP_PATH']} included in .DLL load path")
     handle = ctypes.CDLL(os.path.join(dir_path, libname)) #, winmode=0)
 
     handle.load_model.argtypes = [load_model_inputs]

--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -186,6 +186,11 @@ def init_library():
         os.add_dll_directory(dir_path)
         os.add_dll_directory(abs_path)
         os.add_dll_directory(os.getcwd())
+        if libname == lib_hipblas and "HIP_PATH" in os.environ:
+            print(
+                f"HIP/ROCm SDK at {os.environ['HIP_PATH']} included in .DLL load path"
+            )
+            os.add_dll_directory(os.path.join(os.environ["HIP_PATH"], "bin"))
     handle = ctypes.CDLL(os.path.join(dir_path, libname)) #, winmode=0)
 
     handle.load_model.argtypes = [load_model_inputs]
@@ -920,7 +925,7 @@ def show_new_gui():
         button = ctk.CTkButton(parent, 50, text="Browse", command= lambda a=var,b=searchtext:getfilename(a,b))
         button.grid(row=row+1, column=1, stick="nw")
         return
-    
+
     from subprocess import run, CalledProcessError
     def get_device_names():
         CUdevices = []
@@ -1275,7 +1280,7 @@ def show_new_gui():
         if gpu_choice_var.get()!="All":
             if runopts_var.get() == "Use CLBlast": #if CLBlast selected
                 if (gpu_choice_var.get()) in CLdevices:
-                    gpuchoiceidx = CLdevices.index((gpu_choice_var.get())) 
+                    gpuchoiceidx = CLdevices.index((gpu_choice_var.get()))
             elif runopts_var.get() == "Use CuBLAS" or runopts_var.get() == "Use hipBLAS (ROCm)":
                 if (gpu_choice_var.get()) in CUdevices:
                     gpuchoiceidx = CUdevices.index((gpu_choice_var.get()))
@@ -1417,7 +1422,7 @@ def show_new_gui():
                 horde_workername_var.set(dict["hordeconfig"][4])
                 usehorde_var.set("1")
 
-        
+
     def save_config():
         file_type = [("KoboldCpp Settings", "*.kcpps")]
         filename = asksaveasfile(filetypes=file_type, defaultextension=file_type)
@@ -1580,7 +1585,7 @@ def show_old_gui():
         #load all the vars
         args.threads = int(threads_var.get())
         args.gpulayers = int(gpu_layers_var.get())
-    
+
         args.stream = (stream.get()==1)
         args.smartcontext = (smartcontext.get()==1)
         args.launch = (launchbrowser.get()==1)


### PR DESCRIPTION
## Motivation

I had trouble getting things to work via the `koboldcpp.py` script after building the source on windows. This was down to the the hipBlas/rocBlas .dlls (or their dependencies, I forget which) not loading up even though I had the hip 5.5.1 sdk installed to do build, with the relevant folders on my path.

I turns out windows/python ignores the path unless `winmode=0` is set in python CDLL call. But since that setting had been explicitly commented out in the script I didn't feel comfortable changing it. Here's an alternative, FWIW.

## Changes

* If the rocm/hip sdk is installed on windows, as indicated by the HIP_PATH environment variable then explicitly include the sdk bin folder as a potential location to load the hipBlas/rocBlas .dlls from. The other existing .dll paths are included prior to to this, so if they relevant .dlls are already there the sdk ones should be ignored.