### PR TITLE
Fix `Warning, GUI failed to start: Reason: No module named 'packaging'` after making new venv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy==1.24.4
 sentencepiece==0.1.98
 gguf>=0.1.0
 customtkinter>=5.1.0
+packaging>=23.2


### PR DESCRIPTION
### Motivation

As I was getting a bunch of weird tkinter errors about not being on the main thread with my existing venv, I nuked it and made a new one, then did `pip install -r requirements` to get the dependencies. I then got  `Warning, GUI failed to start: Reason: No module named 'packaging'` on startup.

This adds that module to `requirements.txt`

### Changes

* Adds `packaging` to requirements.txt to clear the above error after creating a new venv and `pip install -r requirements.txt`

### Possible Problems/Concerns

* Maybe this is an upstream issue? Either with koboldcpp or customtkinkter?
* The version >= is just the version that happened to be downloaded today to my machine. I don't know what the actual version requirement is, or how to find out.