### PR TITLE
Remove false-positive "Unable to detect VRAM" warning

### DIFF
--- a/koboldcpp.py
+++ b/koboldcpp.py
@@ -932,6 +932,7 @@ def fetch_gpu_properties(testCL,testCU,testVK):
             faileddetectvram = True
             pass
         if len(FetchedCUdevices)==0:
+            faileddetectvram = False
             try: # Get AMD ROCm GPU names
                 output = subprocess.run(['rocminfo'], capture_output=True, text=True, check=True, encoding='utf-8').stdout
                 device_name = None


### PR DESCRIPTION
There is a warning "Unable to detect VRAM, please set layers manually." that is unconditionally emitted on AMD even though it did not in fact fail, because the "faileddetectvram" flag is never cleared when the initial nvidia-smi query fails before falling back to the rocminfo call.